### PR TITLE
Use `ms` parameter in sleep()

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -35,5 +35,5 @@ function setConfig(config) {
 }
 
 function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, 1000))
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }


### PR DESCRIPTION
Thank you for making a useful extension.

`sleep()` function of `lib.js` takes `ms` as a parameter, but it was never used. This PR fixed it.