### PR TITLE
Use spread syntax instead of webpack-merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "webpack": "^5.38.1",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2",
-    "webpack-merge": "^5.8.0",
     "workbox-webpack-plugin": "^6.1.5"
   },
   "dependencies": {

--- a/webpack.ext.js
+++ b/webpack.ext.js
@@ -1,20 +1,23 @@
 const { join } = require('path');
-const { merge } = require('webpack-merge');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const { staticFileExtensions, commonSrcPath, extSrcPath, extDistPath, baseConfig } = require('./webpack.base');
 
-const extConfig = merge(baseConfig, {
+const extConfig = {
+  ...baseConfig,
   entry: {
+    ...(baseConfig.entry ?? {}),
     'pages/options': [join(extSrcPath, 'pages/options.tsx')],
     'pages/ytm/content': [join(extSrcPath, 'pages/ytm/content.ts')],
   },
   output: {
+    ...(baseConfig.output ?? {}),
     path: extDistPath,
     filename: '[name].js',
   },
 
   plugins: [
+    ...(baseConfig.plugins ?? []),
     new CopyWebpackPlugin({
       patterns: [
         {
@@ -30,6 +33,6 @@ const extConfig = merge(baseConfig, {
       ],
     }),
   ],
-});
+};
 
 module.exports = extConfig;

--- a/webpack.web.js
+++ b/webpack.web.js
@@ -1,5 +1,4 @@
 const { join } = require('path');
-const { merge } = require('webpack-merge');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { GenerateSW } = require('workbox-webpack-plugin');
@@ -7,16 +6,20 @@ const { DefinePlugin } = require('webpack');
 
 const { staticFileExtensions, commonSrcPath, webSrcPath, webDistPath, baseConfig } = require('./webpack.base');
 
-const webConfig = merge(baseConfig, {
+const webConfig = {
+  ...baseConfig,
   entry: {
+    ...(baseConfig.entry ?? {}),
     app: [join(webSrcPath, 'index.tsx')],
   },
   output: {
+    ...(baseConfig.output ?? {}),
     path: webDistPath,
     filename: '[name].js',
   },
 
   plugins: [
+    ...(baseConfig.plugins ?? []),
     new HtmlWebpackPlugin({
       filename: join(webDistPath, 'index.html'),
       template: join(webSrcPath, 'index.html'),
@@ -57,12 +60,14 @@ const webConfig = merge(baseConfig, {
   ],
 
   resolve: {
+    ...(baseConfig.resolve ?? {}),
     fallback: { path: require.resolve('path-browserify') },
   },
 
   devServer: {
+    ...(baseConfig.devServer ?? {}),
     historyApiFallback: true,
   },
-});
+};
 
 module.exports = webConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8069,7 +8069,7 @@ webpack-log@^2.0.0:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
 
-webpack-merge@^5.7.3, webpack-merge@^5.8.0:
+webpack-merge@^5.7.3:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.8.0.tgz#2b39dbf22af87776ad744c390223731d30a68f61"
   integrity sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==


### PR DESCRIPTION
webpack-merge does not have explicit merge rules, so use spread syntax instead.